### PR TITLE
Reformat of README.md for Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 Frikanalen Beta
 ===============
 
-Tools and web for the Norwegian public access tv-channel Frikanalen,
-<URL: http:/www.frikanalen.no/ >.  The latest version of the source is
-available from <URL: http://github.com/Frikanalen >.
+Tools and web for the Norwegian public access TV channel [Frikanalen](http:/www.frikanalen.no/).
 
-This is all under the GNU LGPL license, see the file COPYING for more
-details.
+The latest version of the source is available from [our GitHub page](http://github.com/Frikanalen/).
 
-Read INSTALL.txt to get started with development.
+This is all under the GNU LGPL license, see the file COPYING for more details.
 
-Please report bugs as issues at github and submit patches as pull
-requests there.
+Read `INSTALL.txt` to get started with development.
 
-The project mailing list is available from
-<URL: http://lists.nuug.no/mailman/listinfo/frikanalen >.
+Please report bugs as issues at github and submit patches as pull requests there.
+
+The project mailing list is available from <http://lists.nuug.no/mailman/listinfo/frikanalen/>.


### PR DESCRIPTION
The README file was written as plain-text, but the extension indicates
that it is to be considered as a Markdown-formatted file. This wouldn't
really be more than a nitpick, if it weren't for the fact that GitHub
uses the README as kind-of a banner on the project page, and the current
syntax renders the links invisible.

As much as anything, this is to learn how to get stuff done with git :)
