### PR TITLE
Try to expose the filler flag in the JSON output.

### DIFF
--- a/fkbeta/fkws/serializers.py
+++ b/fkbeta/fkws/serializers.py
@@ -31,6 +31,7 @@ class VideoSerializer(serializers.ModelSerializer):
 			#'videofiles',
 			"categories",
 			"has_tono_records",
+			"is_filler",
 			)
 
 class ScheduleitemSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
I would like to get access to the is_filler flag in the JSON list of videos.  Is this the correct change to do for this?  The patch is untested.
