### PR TITLE
Basic XMLTV support

### DIFF
--- a/fkbeta/agenda/urls.py
+++ b/fkbeta/agenda/urls.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 from django.conf.urls import patterns, url
-import views
+
+from agenda import views
 
 urlpatterns = patterns('',
     url(r'^guide/', views.ProgramguideView.as_view(), name='guide'),
-    url(r'^members/plan/$', views.ProgramplannerView.as_view(), name='manage_video_list'),
-    url(r'^members/video/$', views.ManageVideoList.as_view(), name='manage_video_list'),
-    url(r'^members/video/new/$', views.ManageVideoNew.as_view(), name='manage_video_new'),
-    url(r'^members/video/edit/(?P<id>[0-9]+)$', views.ManageVideoEdit.as_view(), name='manage_video_edit'),
+    url(r'^members/plan/$', views.ProgramplannerView.as_view(), name='manage-video-list'),
+    url(r'^members/video/$', views.ManageVideoList.as_view(), name='manage-video-list'),
+    url(r'^members/video/new/$', views.ManageVideoNew.as_view(), name='manage-video-new'),
+    url(r'^members/video/edit/(?P<id>[0-9]+)$', views.ManageVideoEdit.as_view(), name='manage-video-edit'),
+    url(r'^xmltv/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/?$', views.xmltv, name='xmltv-feed'),
     )

--- a/fkbeta/fk/models.py
+++ b/fkbeta/fk/models.py
@@ -54,7 +54,7 @@ class Organization(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse('org-video-list', kwargs={'orgid': self.id})
+        return reverse('vod-org-video-list', kwargs={'orgid': self.id})
 
 
 class FileFormat(models.Model):
@@ -246,7 +246,7 @@ class Video(models.Model):
         return url
 
     def get_absolute_url(self):
-        return reverse('video-detail', kwargs={'video_id': self.id})
+        return reverse('vod-video-detail', kwargs={'video_id': self.id})
 
 
 class ScheduleitemManager(models.Manager):

--- a/fkbeta/fkbeta/settings/base.py
+++ b/fkbeta/fkbeta/settings/base.py
@@ -14,7 +14,7 @@ from sys import path
 # Do not publish any files with the TONO flag set on the web
 WEB_NO_TONO = True
 
-# Where all the media files are stored
+# Where all the media files are stored (Must have trailing slash)
 FK_MEDIA_URLPREFIX = 'http://simula.gunkies.org/media/'
 FK_MEDIA_ROOT = '/tank/new_media/media'
 
@@ -33,9 +33,17 @@ REST_FRAMEWORK = {
     )
 }
 
+# Channel ID per RFC 2838 (Uniform Resource Identifier for Television Broadcasts)
+CHANNEL_ID = "frikanalen.tv"
+
+# Human readable channel name, higher priority first
+CHANNEL_DISPLAY_NAMES = [u"Frikanalen"]
+
+# URL to the website for references in feeds (No trailing slash)
+SITE_URL = 'http://beta.frikanalen.tv'
+
 # For django-registration
 ACCOUNT_ACTIVATION_DAYS = 7
-
 
 ########## PATH CONFIGURATION
 # Absolute filesystem path to the Django project directory:

--- a/fkbeta/fkbeta/wsgi.py
+++ b/fkbeta/fkbeta/wsgi.py
@@ -31,9 +31,11 @@ def application(environ, start_response):
         if var in environ:
             os.environ[var] = environ[var]
     if 'EXTRA_SITE_DIR' in environ:
-          import site
-          site.addsitedir(environ['EXTRA_SITE_DIR'])
-    sys.path.append(SITE_ROOT)
+        import site
+        site.addsitedir(environ['EXTRA_SITE_DIR'])
+    # Avoid repeatedly adding the when debugging
+    if not SITE_ROOT in sys.path:
+       sys.path.append(SITE_ROOT)
 
     from django.core.wsgi import get_wsgi_application
     _application = get_wsgi_application()

--- a/fkbeta/fkprofile/urls.py
+++ b/fkbeta/fkprofile/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import patterns, include, url
 from fkprofile.views import ProfileDetailView
 
 urlpatterns = patterns('',
-        url(r'^(?P<pk>\w+)/$', ProfileDetailView.as_view(), name='profile_view'),
+        url(r'^(?P<pk>\w+)/$', ProfileDetailView.as_view(), name='profile-view'),
         )

--- a/fkbeta/fkvod/urls.py
+++ b/fkbeta/fkvod/urls.py
@@ -1,15 +1,15 @@
-# Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
+# Copyright (c) 2012-2015 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from fkvod import views
 
 
-urlpatterns = patterns('fkvod.views',
+urlpatterns = [
     url(r'^video/$', views.VideoList.as_view(),
-        name='video-list'),
+        name='vod-video-list'),
     url(r'^video/(?P<video_id>\d+)$', views.VideoDetail.as_view(),
-        name='video-detail'),
+        name='vod-video-detail'),
     url(r'^organization/(?P<orgid>\d+)$', views.OrganizationVideos.as_view(),
-        name='org-video-list'),
-)
+        name='vod-org-video-list'),
+]

--- a/fkbeta/templates/agenda/manage_video_list.html
+++ b/fkbeta/templates/agenda/manage_video_list.html
@@ -32,7 +32,7 @@
 <div class="navigation_container">
     <div class="navigation">
         <div class="inner">
-            <a href="new/">Ny video</a>
+            <a href="{% url 'manage-video-new' %}">New video</a>
         </div>
     </div>
 </div>
@@ -80,7 +80,7 @@
     </li>
     -->
     <li>
-        <a href="/agenda/video/{{ video.id }}">
+        <a href="{% url 'manage-video-edit' video.id %}">
             <b>{{ video.name }}</b>
         <a href="/agenda/video/{{ video.id }}">
     </li>
@@ -91,7 +91,7 @@
     <li>&nbsp;</li>
     {% endif %}
     <li>{{ video.last_broadcast.starttime }}&nbsp;</li>
-    <li><a href="edit/{{ video.id }}">edit</a></li>
+    <li><a href="{% url 'vod-video-detail' video.id %}">public page</a></li>
     <!--<li> {{ video.last_broadcast.duration }} </li> -->
     <!--
     {% if video.header %}

--- a/fkbeta/templates/agenda/xmltv.xml
+++ b/fkbeta/templates/agenda/xmltv.xml
@@ -1,0 +1,24 @@
+<tv generator-info-name="fkbeta.agenda.xmltv">
+  <channel id="{{ channel_id }}">
+    <url>{{ site_url }}</url>
+    {% for channel_display_name in channel_display_names %}
+      <display-name>{{ channel_display_name }}</display-name>
+    {% endfor %}
+  </channel>
+  {% for program in events %}
+    <programme
+      id="{{ channel_id }}"
+      start="{{ program.starttime|date:'YmdHis O' }}"
+      end="{{ program.endtime|date:'YmdHis O' }}">
+    {% if program.video %}
+      <title lang="no">{{ program.video.name }}</title>
+      <desc lang="no"></desc>
+      <url>{{ site_url }}{{ program.video.get_absolute_url }}</url>
+      <length unit="seconds">{{ program.video.duration.seconds }}</length>
+    {% else %}
+      <title lang="no">{{ program.default_name }}</title>
+      <length unit="seconds">{{ program.duration.seconds }}</length>
+    {% endif %}
+    </programme>
+  {% endfor %}
+</tv>


### PR DESCRIPTION
- XMLTV feed - Fixes #60

  Example URL: http://localhost:8000/xmltv/frikanalen.tv_2014-03-01.xml

- Some new settings in base.py for the feed

  Maybe this should become a new model for configuring multiple channels

- Some changes for making url-names consistent
- A check to avoid repeatedly adding to the sys.path (when debugging?)
- Minor changes to the video management, still not done