### PR TITLE
Add XMLTV info page and link to it from the front page.

### DIFF
--- a/fkbeta/agenda/urls.py
+++ b/fkbeta/agenda/urls.py
@@ -11,4 +11,5 @@ urlpatterns = patterns('',
     url(r'^members/video/new/$', views.ManageVideoNew.as_view(), name='manage-video-new'),
     url(r'^members/video/edit/(?P<id>[0-9]+)$', views.ManageVideoEdit.as_view(), name='manage-video-edit'),
     url(r'^xmltv/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/?$', views.xmltv, name='xmltv-feed'),
+    url(r'^xmltv/?$', views.xmltvInfo, name='xmltv-info'),
     )

--- a/fkbeta/agenda/views.py
+++ b/fkbeta/agenda/views.py
@@ -201,6 +201,17 @@ def fill_next_weeks_agenda():
         item.save()
 
 
+def xmltvInfo(request):
+  """ Information about the XMLTV schedule presentation. """
+    return render(
+        request,
+        'agenda/xmltvInfo.html',
+        {
+            'site_url': settings.SITE_URL,
+            'channel_display_names': settings.CHANNEL_DISPLAY_NAMES,
+        })
+
+
 def xmltv(request, year, month, day):
     """ Program guide as XMLTV """
     date = (datetime.datetime(year=int(year), month=int(month), day=int(day))

--- a/fkbeta/templates/agenda/xmltvInfo.html
+++ b/fkbeta/templates/agenda/xmltvInfo.html
@@ -1,0 +1,13 @@
+{% extends "base_generic.html" %}
+
+{% block style %}
+{% endblock %}
+
+{% block content %}
+  <h1>Schedule as XMLTV</h1>
+
+  <p>The {{ channel_display_name }} schedule is provided
+    in <a href="http://www.xmltv.org/">XMLTV format</a>, with one URL
+    per day.  The URL is {{ site_url }}/xmltv/YYYY/MM/DD.</p>
+
+{% endblock %}

--- a/fkbeta/templates/base_generic.html
+++ b/fkbeta/templates/base_generic.html
@@ -186,6 +186,7 @@ h1 {
   <div id="spacer"> </div>
   <div id="footer">
     <p><a href="/api/">REST API</a> |
+      <a href="/xmltv/">XMLTV</a> |
       <a href="http://github.com/Frikanalen">Source code</a>
       &copy; 2009-2015 Foreningen Frikanalen
   </div>


### PR DESCRIPTION
Add new /xmltv/ web page explaining how to get access to the XMLTV schedule
and link to it from  every web page.  This solve issue #75.