### PR TITLE
Provide rolling XMLTV URL, showing the next 7 days.

### DIFF
--- a/fkbeta/agenda/urls.py
+++ b/fkbeta/agenda/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     url(r'^members/video/edit/(?P<id>[0-9]+)$',
         views.ManageVideoEdit.as_view(), name='manage-video-edit'),
     url(r'^xmltv/$', views.xmltv_home, name='xmltv-home'),
+    url(r'^xmltv/upcoming/$', views.xmltv_upcoming, name='xmltv-feed-upcoming'),
     url(r'^xmltv/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/?$',
-        views.xmltv, name='xmltv-feed'),
+        views.xmltv_date, name='xmltv-feed'),
 ]

--- a/fkbeta/agenda/views.py
+++ b/fkbeta/agenda/views.py
@@ -254,13 +254,9 @@ def xmltv_home(request):
     })
 
 
-def xmltv(request, year, month, day):
+def _xmltv(request, events):
     """ Program guide as XMLTV """
-    date = (datetime.datetime(year=int(year), month=int(month), day=int(day))
-            .replace(tzinfo=timezone.utc))
-    events = (Scheduleitem.objects
-              .by_day(date, days=1)
-              .order_by('starttime'))
+
     return render(
         request,
         'agenda/xmltv.xml',
@@ -271,3 +267,19 @@ def xmltv(request, year, month, day):
             'site_url': settings.SITE_URL,
         },
         content_type='application/xml')
+
+
+def xmltv_upcoming(request):
+    events = (Scheduleitem.objects
+              .by_day(days=7)
+              .order_by('starttime'))
+    return _xmltv(request, events)
+
+
+def xmltv_date(request, year, month, day):
+    date = (datetime.datetime(year=int(year), month=int(month), day=int(day))
+            .replace(tzinfo=timezone.utc))
+    events = (Scheduleitem.objects
+              .by_day(date, days=1)
+              .order_by('starttime'))
+    return _xmltv(request, events)

--- a/fkbeta/templates/agenda/xmltv_home.html
+++ b/fkbeta/templates/agenda/xmltv_home.html
@@ -5,7 +5,12 @@
 
   <p>The {{ channel_display_name }} schedule is provided
     in <a href="http://www.xmltv.org/">XMLTV format</a>, with one URL
-    per day.  The URL is <code>/xmltv/YYYY/MM/DD</code>.
+    per day.  The URL is <code>/xmltv/YYYY/MM/DD</code> for a specific
+    day, and <code>/xmltv/upcoming/</code> for the scheduled entries
+    from today 00:00 and 7 days forward.</p>
+
   <p>For example this is the URL of today:
   <p><blockquote><a href="{{ today_url }}">{{ site_url }}{{ today_url }}</a></blockquote>
+  <p>and this is the URL of the coming week:
+  <p><blockquote><a href="{% url 'xmltv-feed-upcoming' %}">{{ site_url }}{% url 'xmltv-feed-upcoming' %}</a></blockquote>
 {% endblock %}


### PR DESCRIPTION
This allow the XMLTV reading add-ons for Kodi that only accept one
URL as its XMLTV source (like the tvguide add-on), to get the
future events.