### PR TITLE
Add upload URL to upload_token endpoint.

### DIFF
--- a/fkbeta/fkws/serializers.py
+++ b/fkbeta/fkws/serializers.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2012-2013 Benjamin Bruheim <grolgh@gmail.com>
 # This file is covered by the LGPLv3 or later, read COPYING for details.
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
@@ -83,9 +84,17 @@ class VideoSerializer(serializers.ModelSerializer):
 
 
 class VideoUploadTokenSerializer(serializers.ModelSerializer):
+    upload_url = serializers.SerializerMethodField()
+
+    def get_upload_url(self, video_upload_token):
+        return settings.FK_UPLOAD_URL
+
     class Meta:
         model = Video
-        fields = ('upload_token',)
+        fields = (
+            'upload_token',
+            'upload_url',
+        )
 
 
 class ScheduleitemSerializer(serializers.ModelSerializer):

--- a/fkbeta/fkws/tests.py
+++ b/fkbeta/fkws/tests.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.utils.dateparse import parse_datetime
@@ -305,9 +306,9 @@ class PermissionsTest(APITestCase):
         self._user_auth('staff_user')
         thing_tests = [
             (VideoFile.objects.get(video__name='tech video'),
-             200, {'upload_token': 'deadbeef'}),
+             200, {'upload_token': 'deadbeef', 'upload_url': settings.FK_UPLOAD_URL}),
             (VideoFile.objects.get(video__name='dummy video'),
-             200, {'upload_token': ''}),
+             200, {'upload_token': '', 'upload_url': settings.FK_UPLOAD_URL}),
         ]
         self._get_upload_token_helper(thing_tests)
 
@@ -315,7 +316,7 @@ class PermissionsTest(APITestCase):
         self._user_auth('nuug_user')
         thing_tests = [
             (VideoFile.objects.get(video__name='tech video'),
-             200, {'upload_token': 'deadbeef'}),
+             200, {'upload_token': 'deadbeef', 'upload_url': settings.FK_UPLOAD_URL}),
             (VideoFile.objects.get(video__name='dummy video'),
              403, {'detail': 'You do not have permission '
                              'to perform this action.'}),


### PR DESCRIPTION
This avoid hardcoding the upload URL in API clients.

Fixes #124.