### PR TITLE
Drop 5 year old /ws/ redirect.

### DIFF
--- a/fkbeta/fkws/urls.py
+++ b/fkbeta/fkws/urls.py
@@ -13,7 +13,6 @@ router.register(r'api/asrun', views.AsRunViewSet)
 router.register(r'api/categories', views.CategoryViewSet)
 
 urlpatterns = [
-    url(r'^ws/(.*)', views.wschange_redirect_view),
     url(r'^api/$', views.api_root, name='api-root'),
     url(r'^api/jukebox_csv$', views.jukebox_csv, name='jukebox-csv'),
     url(r'^api/obtain-token$',

--- a/fkbeta/fkws/views.py
+++ b/fkbeta/fkws/views.py
@@ -6,7 +6,6 @@ import datetime
 
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from django.shortcuts import redirect
 from django.utils import timezone
 from django_filters import rest_framework as djfilters
 from rest_framework import filters
@@ -336,9 +335,3 @@ class VideoFileDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = VideoFile.objects.all()
     serializer_class = VideoFileSerializer
     permission_classes = (IsInOrganizationOrReadOnly,)
-
-
-def wschange_redirect_view(request, path):
-    if request.META['QUERY_STRING']:
-        path += '?%s' % request.META['QUERY_STRING']
-    return redirect('/api/' + path, permanent=True)


### PR DESCRIPTION
Every API client these days use /api/, or should use /api/. :)