### PR TITLE
Run manage.py directly instead of as a argument to python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /srv/frikanalen
 RUN pip install -r requirements-dev.txt
 
 WORKDIR /srv/frikanalen/fkbeta
-RUN python manage.py migrate
-RUN python manage.py loaddata frikanalen
+RUN ./manage.py migrate
+RUN ./manage.py loaddata frikanalen
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["./manage.py", "runserver", "0.0.0.0:8000"]
 
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ docker_run: docker
 docker_push:
 	docker push ${project}
 test:
-	python fkbeta/manage.py test fkbeta
+	fkbeta/manage.py test fkbeta
 	python utils/test_*.py

--- a/infra/roles/web/templates/update.githook.j2
+++ b/infra/roles/web/templates/update.githook.j2
@@ -25,8 +25,8 @@ export DATABASE_NAME={{app_db_name}}
 
 # should only do these when required
 pip install -qr "$dir/requirements.txt"
-python fkbeta/manage.py collectstatic --noinput
-python fkbeta/manage.py migrate --noinput
+fkbeta/manage.py collectstatic --noinput
+fkbeta/manage.py migrate --noinput
 
 sudo systemctl restart fkweb
 


### PR DESCRIPTION
This allow us to switch to python 3 by modifying the #! line
in manage.py instead of having to change python to python3
in several places.

Replated to issue #138.