### PR TITLE
Bring test fileformat list in line with the one in production.

### DIFF
--- a/fkbeta/fk/fixtures/frikanalen.json
+++ b/fkbeta/fk/fixtures/frikanalen.json
@@ -52,7 +52,7 @@
       "model": "fk.fileformat",
       "pk": 8,
       "fields": {
-         "fsname": "mp4"
+         "fsname": "srt"
       }
    },
    {


### PR DESCRIPTION
In production, format 8 is srt, and mp4 is not listed.