### PR TITLE
Move user and key management into ansible

### DIFF
--- a/infra/hosts
+++ b/infra/hosts
@@ -1,3 +1,11 @@
+[encoder]
+obe-hd.frikanalen.no
+
+[tx]
+tx1.frikanalen.no
+tx2.frikanalen.no
+tx3.frikanalen.no
+
 [upload]
 #simula.gunkies.org # deprecated
 file01.frikanalen.no nginx=true domain=upload.frikanalen.no

--- a/infra/roles/common/tasks/main.yml
+++ b/infra/roles/common/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- include_vars: users.yml
+- name: "Create user accounts"
+  user:
+    name: "{{ item.username }}"
+    groups: "sudo,www-data"
+  with_items: "{{ users }}"
+- name: "Add authorized keys"
+  authorized_key:
+    user: "{{ item.username }}"
+    key: "{{ item.ssh_keys }}"
+  with_items: "{{ users }}"
+- name: "Allow admin users to sudo without a password"
+  lineinfile:
+    dest: "/etc/sudoers" # path: in version 2.3
+    state: "present"
+    regexp: "^%sudo"
+    line: "%sudo ALL=(ALL) NOPASSWD: ALL"

--- a/infra/roles/common/vars/users.yml
+++ b/infra/roles/common/vars/users.yml
@@ -1,0 +1,10 @@
+---
+users:
+    - username: "toresbe"
+      realname: "Tore Sinding Bekkedal"
+      ssh_keys: |
+          ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKS8PkeV+Itq1ysleZJ1p/mnukyErXuIPJRuvByCiGot toreb@DESKTOP-7IK2A92
+    - username: "estephaz"
+      realname: "Estephan Zouain"
+      ssh_keys: |
+          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4Re1qbqRbHgJFaSHDYLC0QiFXKHGcMfZ/c38U8WVCMT9zp+CSOODITNQEhdnsBGc/fekDrtTuP7MxEOyB4FVHcN69bXkYDtNUyUCEA9TZP2rJdRs/RUpSZ/3BsWXcqKOaC2pohx19+/9zgt+nZtKzdvsBhJyeFBI47Cs7Ah2LRLgLYo/VrlGzg0rSWFG87nAWp5k+O039vsHqeTMZBQTrKb3+b8vgqYDP38oZ5Bt0++tgh7jlJRDQKBVGhnMByMlx6APomnuc8Oa1MJzX4fBos/IuPdXcj/jQ0lmHLaYcFM2Z3IVf6/pNUqroNLurKmZEuP8kW3yjYO9XzNMLtMVp estephan

--- a/infra/site.yml
+++ b/infra/site.yml
@@ -1,4 +1,11 @@
 ---
+- name: Add volunteers to user database
+  hosts: all
+  become: true
+  gather_facts: false
+  roles:
+    - common
+  tags: common
 - name: Install upload app
   hosts: upload
   become: true


### PR DESCRIPTION
Hey, I've created a common role which is intended to contain basic, common server maintenance roles (site-wide sshd configuration, user configuration, etc). Does this seem like a reasonable solution?