### PR TITLE
Correct table name in initial migration?

### DIFF
--- a/packages/fkweb/fk/migrations/0001_initial.py
+++ b/packages/fkweb/fk/migrations/0001_initial.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', related_query_name='user', to='auth.Permission', verbose_name='user permissions')),
             ],
             options={
-                'db_table': 'auth_user',
+                'db_table': 'fk_user',
             },
             managers=[
                 ('objects', django.contrib.auth.models.UserManager()),


### PR DESCRIPTION
I'm not very familiar with writing good Django migrations, so this is very much a case of "just fixing a string that made things work".

I think the canonical solution would be to rename the database field in a later migration to match the timeline, however there is no such renaming in the migration chain, and I've checked the production database and there indeed the table is called fk_user, not auth_user.

This state of affairs naturally enough wreaks havoc on things (for example, django_admin_log is set up with a foreign key to the table that does not exist - which sqlite3 will happily let you do until you actually try to INSERT), and this fix repairs my issues.