### PR TITLE
Embed tweets

### DIFF
--- a/packages/frontend/components/graphics/twittertimeline.js
+++ b/packages/frontend/components/graphics/twittertimeline.js
@@ -1,0 +1,19 @@
+import React, { useState, useRef, useEffect } from "react";
+import { Timeline } from "react-twitter-widgets";
+
+let ctx;
+
+export default function TwitterTimeline(props) {
+  return (
+    <Timeline
+      dataSource={{
+        sourceType: "profile",
+        screenName: "Frikanalen",
+      }}
+      options={{
+        tweetLimit: "1",
+        chrome: "transparent, noheader, nofooter, noborders, noscrollbar",
+      }}
+    />
+  );
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^17.0.1",
     "react-meta-tags": "^0.7.4",
     "react-moment": "^1.0.0",
+    "react-twitter-widgets": "^1.9.5",
     "resumablejs": "^1.1.0",
     "sass": "^1.29.0",
     "sass-loader": "^10.1.0",

--- a/packages/frontend/pages/graphics/index.tsx
+++ b/packages/frontend/pages/graphics/index.tsx
@@ -56,10 +56,13 @@ function NextUp(props) {
           <img src="/images/frikanalen.png" style={{ margin: "30px", marginLeft: "51px" }} />
         </Row>
         <Row>
+          <div className="mt-3"></div>
+        </Row>
+        <Row>
           <Col style={{ flexGrow: 0 }}>
             <AnalogClock size="500" />
           </Col>
-          <Col>
+          <Col sm={{ size: "auto", offset: 1 }}>
             <h2>Neste program</h2>
             <h3>
               <Moment format={"LT"}>{scheduleJSON.results[currentProgramme].starttime}</Moment>
@@ -68,6 +71,9 @@ function NextUp(props) {
             </h3>
             <h3>{scheduleJSON.results[currentProgramme].video.name}</h3>
           </Col>
+        </Row>
+        <Row>
+          <div className="mt-3"></div>
         </Row>
         <Row>
           <Col style={{ textAlign: "center", marginTop: "30px", fontSize: "21pt" }}>

--- a/packages/frontend/pages/graphics/index.tsx
+++ b/packages/frontend/pages/graphics/index.tsx
@@ -10,6 +10,7 @@ import "moment/locale/nb";
 
 const TrianglifiedDiv = dynamic(() => import("components/graphics/background.js"), { ssr: false });
 const AnalogClock = dynamic(() => import("components/graphics/analogclock.js"), { ssr: false });
+const TwitterTimeline = dynamic(() => import("components/graphics/twittertimeline.js"), { ssr: false });
 
 export async function getServerSideProps(context) {
   const scheduleJSON = await APIGET<fkScheduleJSON>(`scheduleitems/?days=1`);
@@ -61,6 +62,9 @@ function NextUp(props) {
         <Row>
           <Col style={{ flexGrow: 0 }}>
             <AnalogClock size="500" />
+          </Col>
+          <Col sm={{ size: "auto", offset: 1 }}>
+            <TwitterTimeline />
           </Col>
           <Col sm={{ size: "auto", offset: 1 }}>
             <h2>Neste program</h2>

--- a/packages/frontend/pages/graphics/index.tsx
+++ b/packages/frontend/pages/graphics/index.tsx
@@ -40,7 +40,7 @@ function CarouselPage({ duration, children }) {
   return <div style={{ width: "100%", height: "100%" }}>{children}</div>;
 }
 
-function NextUp(props) {
+function ScheduleColumn(props) {
   const { scheduleJSON } = props;
   const currentProgramme = findRunningProgram(scheduleJSON.results) + 1;
   console.log("props:");
@@ -49,6 +49,36 @@ function NextUp(props) {
   console.log(currentProgramme);
   console.log("scheduleJSON:");
   console.log(scheduleJSON);
+
+  return (
+    <Col sm={{ size: "auto", offset: 1 }}>
+      <h2>Neste program</h2>
+      <h3>
+        <Moment format={"LT"}>{scheduleJSON.results[currentProgramme].starttime}</Moment>
+        {": "}
+        {scheduleJSON.results[currentProgramme].video.organization.name}
+      </h3>
+      <h3>{scheduleJSON.results[currentProgramme].video.name}</h3>
+    </Col>
+  );
+}
+
+function TwitterColumn(props) {
+  return (
+    <Col sm={{ size: "auto", offset: 1 }}>
+      <TwitterTimeline />
+    </Col>
+  );
+}
+
+function InfoPanel(props) {
+  const { scheduleJSON } = props;
+  let style;
+  if (readPageStyle() === "twitter") {
+    style = <TwitterColumn />;
+  } else {
+    style = <ScheduleColumn scheduleJSON={scheduleJSON} />;
+  }
 
   return (
     <CarouselPage duration="1000">
@@ -63,18 +93,7 @@ function NextUp(props) {
           <Col style={{ flexGrow: 0 }}>
             <AnalogClock size="500" />
           </Col>
-          <Col sm={{ size: "auto", offset: 1 }}>
-            <TwitterTimeline />
-          </Col>
-          <Col sm={{ size: "auto", offset: 1 }}>
-            <h2>Neste program</h2>
-            <h3>
-              <Moment format={"LT"}>{scheduleJSON.results[currentProgramme].starttime}</Moment>
-              {": "}
-              {scheduleJSON.results[currentProgramme].video.organization.name}
-            </h3>
-            <h3>{scheduleJSON.results[currentProgramme].video.name}</h3>
-          </Col>
+          {style}
         </Row>
         <Row>
           <div className="mt-3"></div>
@@ -94,12 +113,21 @@ function NextUp(props) {
   );
 }
 
+function readPageStyle() {
+  const params = new URLSearchParams(location.search);
+  const style = params.get("style");
+  if (style === "twitter") {
+    return "twitter";
+  }
+  return "schedule";
+}
+
 export default function Index(props) {
   const { scheduleJSON } = props;
   console.log("props in landing function: ", props);
   return (
     <TrianglifiedDiv width="1280" height="720">
-      <NextUp scheduleJSON={scheduleJSON} />
+      <InfoPanel scheduleJSON={scheduleJSON} />
     </TrianglifiedDiv>
   );
   return (

--- a/packages/frontend/yarn.lock
+++ b/packages/frontend/yarn.lock
@@ -3354,6 +3354,11 @@ loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loadjs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loadjs/-/loadjs-4.2.0.tgz#2a0336376397a6a43edf98c9ec3229ddd5abb6f6"
+  integrity sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -4636,6 +4641,13 @@ react-transition-group@^4.4.1:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
+
+react-twitter-widgets@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/react-twitter-widgets/-/react-twitter-widgets-1.9.5.tgz#3c05c0e6f54e79b175dd5e88b8870411e15c5790"
+  integrity sha512-C12GZzY0i7HsaQHOvfVswAJ0fj94VnC7freDK3Zb72tGEnLDwWDKApZ0yKoO4ywNqa/fcDNCU7JN9FUbQLO5VA==
+  dependencies:
+    loadjs "^4.2.0"
 
 react@^17.0.1:
   version "17.0.1"


### PR DESCRIPTION
The graphics code has been extended to add support for showing the latest tweet from @FriKanalen.

A URL parameter is sent to determine if the schedule or a tweet should be shown next to the analogue clock.

Sending `?style=twitter` will show the latest tweet, anything else will revert to showing the schedule.

<img width="1279" alt="Screenshot 2020-11-30 at 15 08 33" src="https://user-images.githubusercontent.com/4302925/100620030-37045b80-331e-11eb-9f7c-d4175ad1fa7d.png">
